### PR TITLE
Feature/file id generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint \"packages/*/src/**/*.{ts,tsx}\"",
     "type-check": "tsc --noEmit",
     "type-check:watch": "yarn type-check -- --watch",
-    "start": "onchange 'packages/*/src/**/*.{ts,tsx}' -- yarn build",
+    "start": "onchange 'packages/*/src/**/*.{ts,tsx}' -- yarn build:sources",
     "test": "jest",
     "test:coverage": "yarn test -- --collectCoverage",
     "test:coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",

--- a/packages/node-resizin/src/__tests__/upload.test.ts
+++ b/packages/node-resizin/src/__tests__/upload.test.ts
@@ -25,7 +25,7 @@ describe('Upload image', () => {
     });
 
     it('should reject if image id is not provided', () => {
-        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl' })('asd3f4as5lf')).rejects.toThrow(
+        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl', autoId: false })('asd3f4as5lf')).rejects.toThrow(
             'Image id is missing',
         );
     });

--- a/packages/node-resizin/src/__tests__/upload.test.ts
+++ b/packages/node-resizin/src/__tests__/upload.test.ts
@@ -25,11 +25,13 @@ describe('Upload image', () => {
     });
 
     it('should reject if image id is not provided', () => {
-        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl' })()).rejects.toThrow('Image id is missing');
+        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl' })('asd3f4as5lf')).rejects.toThrow(
+            'Image id is missing',
+        );
     });
 
     it('should reject if file is not provided', () => {
-        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl' })('14')).rejects.toThrow('File is missing');
+        return expect(uploadImage({ apiKey: 'asdf12ja55ls5djfl' })(null, 'asd45adsf4')).rejects.toThrow('File is missing');
     });
 
     it('pass url and options to fetch', () => {
@@ -37,7 +39,7 @@ describe('Upload image', () => {
         responseObj.json.mockResolvedValue({});
         fetchMock.mockResolvedValue(responseObj);
 
-        return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com' })('14', 'adsfjlsadjf').then(
+        return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com' })('adsfjlsadjf', '14').then(
             () => {
                 expect(fetchMock.mock.calls[0][0]).toEqual('resizin-url.com/api/v1/image/upload');
                 expect(fetchMock.mock.calls[0][1]).toHaveProperty('headers.Authorization', 'Key asdf12ja55ls5djfl');
@@ -57,8 +59,8 @@ describe('Upload image', () => {
         fetchMock.mockResolvedValue(responseObj);
 
         return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com', fileType: 'my-type' })(
-            '14',
             'adsfjlsadjf',
+            '14',
         ).then(() => {
             expect(fetchMock.mock.calls[0][0]).toEqual('resizin-url.com/api/v1/file/upload');
         });
@@ -69,7 +71,7 @@ describe('Upload image', () => {
         responseObj.json.mockResolvedValue({});
         fetchMock.mockResolvedValue(responseObj);
 
-        return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com' })('16', 'puopuihoh').then(
+        return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com' })('puopuihoh', '16').then(
             () => {
                 const formData = fetchMock.mock.calls[0][1].body;
                 expect(formData.append.mock.calls[1][1]).toEqual('puopuihoh');
@@ -84,8 +86,8 @@ describe('Upload image', () => {
         fetchMock.mockResolvedValue(responseObj);
 
         return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com', fileType: 'my-type' })(
-            '15',
             'bncvbcvb',
+            '15',
         ).then(() => {
             const formData = fetchMock.mock.calls[0][1].body;
             expect(formData.append.mock.calls[1][1]).toEqual('bncvbcvb');
@@ -99,8 +101,8 @@ describe('Upload image', () => {
         fetchMock.mockResolvedValue(responseObj);
 
         return uploadImage({ apiKey: 'asdf12ja55ls5djfl', serverUrl: 'resizin-url.com' })(
-            '15',
             'asdasf89',
+            '15',
             'image/jpeg',
         ).then(() => {
             const formData = fetchMock.mock.calls[0][1].body;

--- a/packages/resizin/README.md
+++ b/packages/resizin/README.md
@@ -11,7 +11,7 @@ Core package for uploading images and building url of images from [Resizin](http
     * [`buildUrl(serverUrl, bucket, imageId, options)`](#buildurlserverurl-bucket-imageid-options-options-string)
     * [`buildUrlFactory(options)`](#buildurlfactoryoptions-clientoptions-function)
     * [Modifiers](#modifiers)
-    * [`upload(serverUrl, apiKey, imageId, file, options)`](#uploadserverurl-apikey-imageid-null-file-uploadoptions-options-promise)
+    * [`upload(serverUrl, apiKey, imageId, file, options)`](#uploadserverurl-apikey-imageid--null-file-uploadoptions-options-promise)
     * [`uploadFactory(options)`](#uploadfactoryoptions-options-function)
 
 ## Installation
@@ -90,7 +90,7 @@ interface ClientOptions {
 }
 ```
 
-Returns [`buildUrl`](#buildurlserverurl-bucket-imageid-options-options-string) method with shortened interface `buildUrl(imageId: string, options: options)`
+Returns [`buildUrl`](#buildurlserverurl-bucket-imageid-options-options-string) method with shortened interface **`buildUrl(imageId: string, options: options)`**
 
 ```js
 import { buildUrlFactory } from 'resizin';

--- a/packages/resizin/README.md
+++ b/packages/resizin/README.md
@@ -11,7 +11,7 @@ Core package for uploading images and building url of images from [Resizin](http
     * [`buildUrl(serverUrl, bucket, imageId, options)`](#buildurlserverurl-bucket-imageid-options-options-string)
     * [`buildUrlFactory(options)`](#buildurlfactoryoptions-clientoptions-function)
     * [Modifiers](#modifiers)
-    * [`upload(serverUrl, apiKey, imageId, file)`](#uploadserverurl-apikey-imageid-file-promise)
+    * [`upload(serverUrl, apiKey, imageId, file, options)`](#uploadserverurl-apikey-imageid-null-file-uploadoptions-options-promise)
     * [`uploadFactory(options)`](#uploadfactoryoptions-options-function)
 
 ## Installation
@@ -43,10 +43,11 @@ const imageUrl = buildUrl('walle',  { width: 250 });
 
 // Uploading image
 const upload = uploadFactory({
-    apiKey: config.RESIZIN_API_KEY
+    apiKey: config.RESIZIN_API_KEY,
+    autoId: true,
 })
 
-upload(client.upload("Walle on the road", files[0]);
+upload(files[0]);
 ```
 
 ## API
@@ -135,11 +136,12 @@ You can try all modifiers at <a href="https://resizin.com/" target="_blank">Inte
 ___
 
 
-### `upload(serverUrl, apiKey, imageId, file, uploadOptions: Options): Promise`
+### `upload(serverUrl, apiKey, imageId = null, file, uploadOptions: Options): Promise`
 
 ```typescript
 interface Options {
     fileType?: 'image'|'file'; // default is 'image'
+    autoId?: boolean;
 }
 ```
 
@@ -158,12 +160,35 @@ upload(
 });
 ```
 
-To avoid repeating information that doesn't change across an app like `serverUrl` and `apiKey`, take a look at [`uploadFactory`](#uploadfactoryoptions-options-function).
+To avoid repeating information that doesn't change across an app like `serverUrl` and `apiKey`, **take a look at [`uploadFactory`](#uploadfactoryoptions-options-function)**.
 
     
 Examples from the wild:
 
-#### Upload in client (get file using jQuery)
+#### Upload in client (React example)
+
+
+```js
+import React from 'react';
+import { upload } from 'resizin';
+
+const uploadFile = file =>
+    upload(
+        'https://api.resizin.com',
+        config.RESIZIN_API_KEY,
+        'imageid', 
+        files[0]
+    ).then(() => {
+        ...      
+    });
+
+
+const UploadImageInput = () => (
+    <input type="file" id="fileinput" onChange={e => uploadFile(e.target.files[0])} />
+);
+```
+
+#### Upload in client (jQuery example)
 
 Assume you have a file input in your page
 
@@ -211,8 +236,11 @@ var promise = resizin.upload(
 interface Options {
     serverUrl?: string;
     apiKey: string;
+    autoId?: boolean;
 }
 ```
+
+the factory returns function **`upload(file, imageId?)`**
 
 ```js
 import { uploadFactory } from 'resizin';
@@ -225,13 +253,26 @@ const upload = uploadFactory({
 upload("Walle on the road", files[0]);
 ```
 
-You can omit `serverUrl` option when it's  `https://api.resizin.com` as it is a default value
+#### Usage tips
 
-```js
-import { uploadFactory } from 'resizin';
+* You can omit `serverUrl` option when it's  `https://api.resizin.com` as it is a default value
 
-const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY });
-```
+    ```js
+    import { uploadFactory } from 'resizin';
+
+    const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY });
+    ```
+
+* If you set `autoId` option to `true`, you don't have to provide an image id and make an upload call more simple
+
+    ```js
+    import { uploadFactory } from 'resizin';
+
+    const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY, autoId: true });
+
+    upload(files[0]);
+    upload(files[1]);
+    ```
 
 ## License
 

--- a/packages/resizin/README.md
+++ b/packages/resizin/README.md
@@ -44,7 +44,6 @@ const imageUrl = buildUrl('walle',  { width: 250 });
 // Uploading image
 const upload = uploadFactory({
     apiKey: config.RESIZIN_API_KEY,
-    autoId: true,
 })
 
 upload(files[0]);
@@ -141,7 +140,7 @@ ___
 ```typescript
 interface Options {
     fileType?: 'image'|'file'; // default is 'image'
-    autoId?: boolean;
+    autoId?: boolean;          // default is true 
 }
 ```
 
@@ -153,7 +152,7 @@ import { upload } from 'resizin';
 upload(
     'https://api.resizin.com',
     config.RESIZIN_API_KEY,
-    'Walle on the road',
+    null,
     files[0],
 ).then(() => {
     ...
@@ -176,7 +175,7 @@ const uploadFile = file =>
     upload(
         'https://api.resizin.com',
         config.RESIZIN_API_KEY,
-        'imageid', 
+        null,
         files[0]
     ).then(() => {
         ...      
@@ -207,7 +206,7 @@ $('#fileinput').live('change', function(){
     upload(
         'https://api.resizin.com',
         config.RESIZIN_API_KEY,
-        'imageid', 
+        null,
         files[0]
     ).then(() => {
         ...      
@@ -225,7 +224,7 @@ const file = fs.createReadStream(__dirname + '/myfile.png');
 var promise = resizin.upload(
     'https://api.resizin.com',
     config.RESIZIN_API_KEY,
-    'imageid', 
+    null, 
     file
 );
 ```
@@ -263,15 +262,15 @@ upload("Walle on the road", files[0]);
     const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY });
     ```
 
-* If you set `autoId` option to `true`, you don't have to provide an image id and make an upload call more simple
+* If you set `autoId` option to `false`, you prevent auto generating image id, **but you must to provide it by yourself!**
 
     ```js
     import { uploadFactory } from 'resizin';
 
-    const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY, autoId: true });
+    const upload = uploadFactory({ apiKey: config.RESIZIN_API_KEY, autoId: false });
 
-    upload(files[0]);
-    upload(files[1]);
+    upload(files[0], 'id-image-1');
+    upload(files[1], 'id-image-2');
     ```
 
 ## License

--- a/packages/resizin/package.json
+++ b/packages/resizin/package.json
@@ -30,8 +30,10 @@
     "@types/isomorphic-fetch": "^0.0.35",
     "@types/lodash": "^4.14.136",
     "@types/promise-polyfill": "^6.0.3",
+    "@types/uuid": "^3.4.5",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.11.1",
-    "promise-polyfill": "^8.1.3"
+    "promise-polyfill": "^8.1.3",
+    "uuid": "^3.3.3"
   }
 }

--- a/packages/resizin/src/upload/__tests__/upload.test.ts
+++ b/packages/resizin/src/upload/__tests__/upload.test.ts
@@ -33,8 +33,10 @@ describe('Upload image', () => {
         return expect(uploadImage('img.resizin.com')).rejects.toThrow('API KEY is missing');
     });
 
-    it('should reject if image id is not provided', () => {
-        return expect(uploadImage('img.resizin.com', 'asdf12ja55ls5djfl')).rejects.toThrow('Image id is missing');
+    it('should reject if image id is not provided and auto generating ids is disabled', () => {
+        return expect(
+            uploadImage('img.resizin.com', 'asdf12ja55ls5djfl', undefined, undefined, { autoId: false }),
+        ).rejects.toThrow('Image id is missing');
     });
 
     it('should reject if file is not provided', () => {
@@ -153,6 +155,16 @@ describe('Upload image', () => {
         });
     });
 
+    it('should auto generate image id in default and thus not reject if id not provided', () => {
+        responseObj.status = 200;
+        responseObj.json.mockResolvedValue({ uploaded: true });
+        fetchMock.mockResolvedValue(responseObj);
+
+        return expect(uploadImage('img.resizin.com', 'asdf12ja55ls5djfl', undefined, 'asdfjaldsfj')).resolves.toEqual({
+            uploaded: true,
+        });
+    });
+
     it('should not reject if image id not provided but generating ids set to true', () => {
         responseObj.status = 200;
         responseObj.json.mockResolvedValue({ uploaded: true });
@@ -184,11 +196,9 @@ describe('Upload image', () => {
         responseObj.json.mockResolvedValue({});
         fetchMock.mockResolvedValue(responseObj);
 
-        return uploadImage('img.resizin.com', 'asdf12ja55ls5djfl', '29', 'asdfjaldsfj', { autoId: true }).then(
-            () => {
-                const formData = fetchMock.mock.calls[0][1].body;
-                expect(formData.append.mock.calls[0]).toEqual(['id', '29']);
-            },
-        );
+        return uploadImage('img.resizin.com', 'asdf12ja55ls5djfl', '29', 'asdfjaldsfj', { autoId: true }).then(() => {
+            const formData = fetchMock.mock.calls[0][1].body;
+            expect(formData.append.mock.calls[0]).toEqual(['id', '29']);
+        });
     });
 });

--- a/packages/resizin/src/upload/__tests__/uploadFactory.test.ts
+++ b/packages/resizin/src/upload/__tests__/uploadFactory.test.ts
@@ -4,6 +4,8 @@ import { DEFAULT_API_URL } from '../../constants';
 
 jest.mock('../upload');
 
+const uploadMock = upload as jest.Mock<upload>;
+
 describe('BuildUpload factory', () => {
     beforeEach(() => {
         upload.mockReset();
@@ -14,8 +16,8 @@ describe('BuildUpload factory', () => {
 
         clientUpload('imageId', 'file');
 
-        expect(upload).toHaveBeenCalledTimes(1);
-        expect(upload.mock.calls[0][0]).toEqual('my-resizin.com');
+        expect(uploadMock).toHaveBeenCalledTimes(1);
+        expect(uploadMock.mock.calls[0][0]).toEqual('my-resizin.com');
     });
 
     it('should use default api url for upload when none provided', () => {
@@ -23,8 +25,8 @@ describe('BuildUpload factory', () => {
 
         clientUpload('imageId', 'file');
 
-        expect(upload).toHaveBeenCalledTimes(1);
-        expect(upload.mock.calls[0][0]).toEqual(DEFAULT_API_URL);
+        expect(uploadMock).toHaveBeenCalledTimes(1);
+        expect(uploadMock.mock.calls[0][0]).toEqual(DEFAULT_API_URL);
     });
 
     it('should supply file type to upload function', () => {
@@ -32,8 +34,8 @@ describe('BuildUpload factory', () => {
 
         clientUpload('imageId', 'file');
 
-        expect(upload).toHaveBeenCalledTimes(1);
-        expect(upload.mock.calls[0][4]).toEqual({ fileType: 'file' });
+        expect(uploadMock).toHaveBeenCalledTimes(1);
+        expect(uploadMock.mock.calls[0][4]).toHaveProperty('fileType', 'file');
     });
 
     it('should supply none file type to upload function when none received', () => {
@@ -41,7 +43,19 @@ describe('BuildUpload factory', () => {
 
         clientUpload('imageId', 'file');
 
-        expect(upload).toHaveBeenCalledTimes(1);
-        expect(upload.mock.calls[0][4]).toEqual({ fileType: undefined });
+        expect(uploadMock).toHaveBeenCalledTimes(1);
+        expect(uploadMock.mock.calls[0][4]).toHaveProperty('fileType', undefined);
+    });
+
+    it('should supply autoId option to the underlying upload function', () => {
+        const clientUpload = uploadFactory({ apiKey: 'key', autoId: true });
+        const clientUpload2 = uploadFactory({ apiKey: 'key' });
+
+        clientUpload('imageId', 'file');
+        clientUpload2('imageId', 'file');
+
+        expect(uploadMock).toHaveBeenCalledTimes(2);
+        expect(uploadMock.mock.calls[0][4]).toHaveProperty('autoId', true);
+        expect(uploadMock.mock.calls[1][4]).toHaveProperty('autoId', undefined);
     });
 });

--- a/packages/resizin/src/upload/__tests__/uploadFactory.test.ts
+++ b/packages/resizin/src/upload/__tests__/uploadFactory.test.ts
@@ -8,42 +8,54 @@ const uploadMock = upload as jest.Mock<upload>;
 
 describe('BuildUpload factory', () => {
     beforeEach(() => {
-        upload.mockReset();
+        uploadMock.mockReset();
     });
 
     it('should use provided server url for upload when provided', () => {
         const clientUpload = uploadFactory({ serverUrl: 'my-resizin.com', apiKey: 'key' });
 
-        clientUpload('imageId', 'file');
+        clientUpload('file', 'imageId');
 
-        expect(uploadMock).toHaveBeenCalledTimes(1);
         expect(uploadMock.mock.calls[0][0]).toEqual('my-resizin.com');
     });
 
     it('should use default api url for upload when none provided', () => {
         const clientUpload = uploadFactory({ apiKey: 'key' });
 
-        clientUpload('imageId', 'file');
+        clientUpload('file', 'imageId');
 
-        expect(uploadMock).toHaveBeenCalledTimes(1);
         expect(uploadMock.mock.calls[0][0]).toEqual(DEFAULT_API_URL);
     });
 
     it('should supply file type to upload function', () => {
         const clientUpload = uploadFactory({ apiKey: 'key', fileType: 'file' });
 
-        clientUpload('imageId', 'file');
+        clientUpload('file', 'imageId');
 
-        expect(uploadMock).toHaveBeenCalledTimes(1);
         expect(uploadMock.mock.calls[0][4]).toHaveProperty('fileType', 'file');
+    });
+
+    it('should supply provided imageId to the underlying upload function', () => {
+        const clientUpload = uploadFactory({ apiKey: 'key', fileType: 'file' });
+
+        clientUpload('file', 'image_id_1');
+
+        expect(uploadMock.mock.calls[0][2]).toEqual('image_id_1');
+    });
+
+    it('should supply null to the underlying upload function if imageId not provided', () => {
+        const clientUpload = uploadFactory({ apiKey: 'key', fileType: 'file' });
+
+        clientUpload('file');
+
+        expect(uploadMock.mock.calls[0][2]).toEqual(null);
     });
 
     it('should supply none file type to upload function when none received', () => {
         const clientUpload = uploadFactory({ apiKey: 'key' });
 
-        clientUpload('imageId', 'file');
+        clientUpload('file', 'imageId');
 
-        expect(uploadMock).toHaveBeenCalledTimes(1);
         expect(uploadMock.mock.calls[0][4]).toHaveProperty('fileType', undefined);
     });
 
@@ -51,8 +63,8 @@ describe('BuildUpload factory', () => {
         const clientUpload = uploadFactory({ apiKey: 'key', autoId: true });
         const clientUpload2 = uploadFactory({ apiKey: 'key' });
 
-        clientUpload('imageId', 'file');
-        clientUpload2('imageId', 'file');
+        clientUpload('file', 'imageId');
+        clientUpload2('file', 'imageId');
 
         expect(uploadMock).toHaveBeenCalledTimes(2);
         expect(uploadMock.mock.calls[0][4]).toHaveProperty('autoId', true);

--- a/packages/resizin/src/upload/upload.ts
+++ b/packages/resizin/src/upload/upload.ts
@@ -21,7 +21,7 @@ interface UploadOptions {
     autoId?: boolean;
 }
 
-const defaultOptions = { fileType: type.IMAGE, autoId: false };
+const defaultOptions = { fileType: type.IMAGE, autoId: true };
 
 const uploadImage = (
     serverUrl: string,

--- a/packages/resizin/src/upload/upload.ts
+++ b/packages/resizin/src/upload/upload.ts
@@ -1,6 +1,7 @@
 import { defaults } from 'lodash';
 import fetch from 'isomorphic-fetch';
 import Promise from 'promise-polyfill';
+import getUniqueId from 'uuid/v1';
 
 const type = {
     IMAGE: 'image',
@@ -17,7 +18,10 @@ export type FileType = 'file' | 'image';
 interface UploadOptions {
     fileType?: FileType;
     mime?: string;
+    autoId?: boolean;
 }
+
+const defaultOptions = { fileType: type.IMAGE, autoId: false };
 
 const uploadImage = (
     serverUrl: string,
@@ -27,22 +31,22 @@ const uploadImage = (
     uploadOptions?: UploadOptions,
 ) => {
     return Promise.resolve().then(() => {
+        const options = defaults(uploadOptions, defaultOptions);
+
         if (!serverUrl) {
             throw new Error('Url is missing!');
         }
         if (!apiKey) {
             throw new Error('API KEY is missing!');
         }
-        if (!imageId) {
+        if (!imageId && !options.autoId) {
             throw new Error('Image id is missing!');
         }
         if (!file) {
             throw new Error('File is missing!');
         }
 
-        const options = defaults(uploadOptions, { fileType: type.IMAGE });
         const fileType = options.fileType === type.IMAGE ? options.fileType : type.FILE;
-
         const fetchOptions: any = {
             method: 'POST',
             headers: {
@@ -51,6 +55,7 @@ const uploadImage = (
         };
 
         const formData = new FormData();
+        const id = options.autoId && !imageId ? getUniqueId() : imageId;
 
         // TODO - how to deal with FormData having different interface in different environments.
         // At Browser app there is a native FormData which accepts only filename as a third parameter
@@ -60,7 +65,7 @@ const uploadImage = (
             contentType: options.mime || mimeByType[fileType],
         } as any;
 
-        formData.append('id', imageId);
+        formData.append('id', id);
         formData.append('file', file, fileMeta);
         fetchOptions.body = formData;
 

--- a/packages/resizin/src/upload/upload.ts
+++ b/packages/resizin/src/upload/upload.ts
@@ -26,7 +26,7 @@ const defaultOptions = { fileType: type.IMAGE, autoId: false };
 const uploadImage = (
     serverUrl: string,
     apiKey: string,
-    imageId: string,
+    imageId: string|null,
     file: string,
     uploadOptions?: UploadOptions,
 ) => {

--- a/packages/resizin/src/upload/upload.ts
+++ b/packages/resizin/src/upload/upload.ts
@@ -27,7 +27,7 @@ const uploadImage = (
     serverUrl: string,
     apiKey: string,
     imageId: string|null,
-    file: string,
+    file: string|Blob,
     uploadOptions?: UploadOptions,
 ) => {
     return Promise.resolve().then(() => {
@@ -55,7 +55,7 @@ const uploadImage = (
         };
 
         const formData = new FormData();
-        const id = options.autoId && !imageId ? getUniqueId() : imageId;
+        const id = options.autoId && !imageId ? getUniqueId() : imageId as string;
 
         // TODO - how to deal with FormData having different interface in different environments.
         // At Browser app there is a native FormData which accepts only filename as a third parameter

--- a/packages/resizin/src/upload/uploadFactory.ts
+++ b/packages/resizin/src/upload/uploadFactory.ts
@@ -5,16 +5,21 @@ interface ClientOptions {
     serverUrl?: string;
     apiKey: string;
     fileType?: FileType;
+    autoId?: boolean;
 }
 
 const uploadFactory = (options: ClientOptions = { apiKey: '' }) => (
     imageId: string,
     file: string,
-    mime: string,
+    mime?: string,
 ) => {
     const serverUrl = options.serverUrl || DEFAULT_API_URL;
 
-    return upload(serverUrl, options.apiKey, imageId, file, { fileType: options.fileType, mime });
+    return upload(serverUrl, options.apiKey, imageId, file, {
+        fileType: options.fileType,
+        mime,
+        autoId: options.autoId,
+    });
 };
 
 export default uploadFactory;

--- a/packages/resizin/src/upload/uploadFactory.ts
+++ b/packages/resizin/src/upload/uploadFactory.ts
@@ -9,13 +9,13 @@ interface ClientOptions {
 }
 
 const uploadFactory = (options: ClientOptions = { apiKey: '' }) => (
-    imageId: string,
-    file: string,
+    file: string|Blob,
+    imageId?: string,
     mime?: string,
 ) => {
     const serverUrl = options.serverUrl || DEFAULT_API_URL;
 
-    return upload(serverUrl, options.apiKey, imageId, file, {
+    return upload(serverUrl, options.apiKey, imageId || null, file, {
         fileType: options.fileType,
         mime,
         autoId: options.autoId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,6 +1827,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^3.4.5":
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
+  integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
@@ -7893,7 +7900,7 @@ utile@0.3.x:
     ncp "1.0.x"
     rimraf "2.x.x"
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==


### PR DESCRIPTION
Based on #14, Resolves #4

Add an `autoId` option to the `upload` function which get you rid of neccesity to supply image id when uploading.